### PR TITLE
chore(pom.xml): Downgrade do Java para versao 11 e Spring Boot para 2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.2</version>
+		<version>2.7.18</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.tokiomarine</groupId>
@@ -28,7 +28,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>17</java.version>
+		<java.version>11</java.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Alteração da versão do Java para 11, conforme especificado no teste, e ajuste do Spring Boot para a versão 2.7.18, a última estável da linha 2.x.x compatível com Java 11.